### PR TITLE
feat: 세션 정보 조회하는 API

### DIFF
--- a/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/auth/controller/SessionApi.java
+++ b/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/auth/controller/SessionApi.java
@@ -1,0 +1,21 @@
+package org.re.hq.auth.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.re.hq.auth.dto.SessionInfoResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/session")
+@RequiredArgsConstructor
+public class SessionApi {
+    @GetMapping
+    public SessionInfoResponse getSessionInfo(
+        HttpServletRequest request
+    ) {
+        var session = request.getSession(false);
+        return SessionInfoResponse.from(session);
+    }
+}

--- a/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/auth/dto/SessionInfoResponse.java
+++ b/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/auth/dto/SessionInfoResponse.java
@@ -1,0 +1,45 @@
+package org.re.hq.auth.dto;
+
+import jakarta.servlet.http.HttpSession;
+import lombok.Getter;
+import org.re.hq.common.dto.SuccessResponse;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+@Getter
+public class SessionInfoResponse extends SuccessResponse<SessionInfoResponse.SessionInfo> {
+    public SessionInfoResponse(SessionInfo session) {
+        super(session);
+    }
+
+    public record SessionInfo(
+        String id,
+        ZonedDateTime createdAt,
+        ZonedDateTime lastAccessedAt,
+        ZonedDateTime expireAt
+    ) {
+        private static final SessionInfo INVALIDATED_SESSION = new SessionInfo("INVALIDATED", null, null, null);
+
+        private static SessionInfo from(HttpSession session) {
+            var createdAt = LocalDateTime.ofEpochSecond(session.getCreationTime() / 1000, 0, ZoneOffset.UTC);
+            var lastAccessedAt = LocalDateTime.ofEpochSecond(session.getLastAccessedTime() / 1000, 0, ZoneOffset.UTC);
+            var expireAt = lastAccessedAt.plusSeconds(session.getMaxInactiveInterval());
+            return new SessionInfo(
+                session.getId(),
+                ZonedDateTime.ofLocal(createdAt, ZoneOffset.UTC, null),
+                ZonedDateTime.ofLocal(lastAccessedAt, ZoneOffset.UTC, null),
+                ZonedDateTime.ofLocal(expireAt, ZoneOffset.UTC, null)
+            );
+        }
+    }
+
+    public static SessionInfoResponse from(HttpSession session) {
+        try {
+            return new SessionInfoResponse(SessionInfo.from(session));
+        } catch (IllegalStateException | NullPointerException e) {
+            return new SessionInfoResponse(SessionInfo.INVALIDATED_SESSION);
+        }
+    }
+}

--- a/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/config/WebSecurityConfig.java
+++ b/roadeye-api/roadeye-api-hq/src/main/java/org/re/hq/config/WebSecurityConfig.java
@@ -100,7 +100,7 @@ public class WebSecurityConfig {
             return http
                 .securityMatcher("/api/**")
                 .authorizeHttpRequests(authorize -> authorize
-                    .requestMatchers("/api/auth/sign-in").permitAll()
+                    .requestMatchers("/api/auth/sign-in", "/api/session").permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/company/quotes").permitAll()
                     .anyRequest().hasAuthority(AuthMemberType.USER.getValue())
                 )


### PR DESCRIPTION
<!-- 제목: [Feature/Bug/Refactor 등] (이슈와 동일하게 사용) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

---

## 📌 관련 이슈

- resolves #23 

## 🚀 PR 개요

현재 세션에 대한 정보를 조회하는 API를 추가합니다.
세션에 접근하기 때문에 세션 연장 기능도 가능합니다.

## 📝 리뷰 포인트

> 리뷰어가 집중해서 봐야할 부분을 작성해주세요. 소스 코드에 대한 링크를 첨부하면 좋습니다.

## 💬 할 말

> 추가로 하고 싶은 말이 있다면 작성해주세요.

## 📚 참고 자료
- [Jakrata Servlet/Session Timeouts](https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0#session-timeouts)
