### PR TITLE
fix: 시동 끌 때 NPE 가능성

### DIFF
--- a/roadeye-api/roadeye-api-hub/src/main/java/org/re/mdtlog/service/MdtIgnitionService.java
+++ b/roadeye-api/roadeye-api-hub/src/main/java/org/re/mdtlog/service/MdtIgnitionService.java
@@ -12,6 +12,8 @@ import org.re.mdtlog.dto.MdtIgnitionOnMessage;
 import org.re.mdtlog.messaging.MdtLogMessagingService;
 import org.springframework.stereotype.Service;
 
+import java.util.Objects;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -25,7 +27,7 @@ public class MdtIgnitionService {
 
     public void ignitionOff(TransactionUUID tuid, MdtIgnitionOffMessage dto, MdtLogRequestTimeInfo timeInfo) {
         var car = carDomainService.getCarById(dto.carId());
-        if (!car.getMdtStatus().getActiveTuid().equals(tuid)) {
+        if (Objects.equals(car.getMdtStatus().getActiveTuid(), tuid)) {
             throw new AppException(MdtLogExceptionCode.TUID_ERROR);
         }
 


### PR DESCRIPTION
<!-- 제목: [Feature/Bug/Refactor 등] (이슈와 동일하게 사용) -->
<!-- 아래에 이슈 번호를 매겨주세요 -->

---

## 📌 관련 이슈

- resolves #127 

## 🚀 PR 개요

> 활성화된 트랜잭션ID가 없는 경우 `car.getMdtStatus().getActiveTuid()` 가 NULL을 반환하여 `car.getMdtStatus().getActiveTuid().equals(...)`가 NPE를 발생시키므로 이를 수정함.

## 📝 리뷰 포인트

> 리뷰어가 집중해서 봐야할 부분을 작성해주세요. 소스 코드에 대한 링크를 첨부하면 좋습니다.

## 💬 할 말

> 추가로 하고 싶은 말이 있다면 작성해주세요.

## 📚 참고 자료
